### PR TITLE
Add smart album tooling with persistence

### DIFF
--- a/pkg/immich/client_test.go
+++ b/pkg/immich/client_test.go
@@ -1,0 +1,112 @@
+package immich
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientPingSuccess(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		assert.Equal(t, "/api/server-info/ping", r.URL.Path)
+		assert.Equal(t, "test-key", r.Header.Get("x-api-key"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key", time.Second)
+	err := client.Ping(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestClientPingError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key", time.Second)
+	err := client.Ping(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ping failed with status")
+}
+
+func TestClientRequestSendsPayload(t *testing.T) {
+	t.Parallel()
+
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{\"ok\":true}"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key", time.Second)
+
+	var result struct {
+		OK bool `json:"ok"`
+	}
+
+	err := client.post(context.Background(), server.URL+"/test", map[string]string{"hello": "world"}, &result)
+
+	assert.NoError(t, err)
+	assert.True(t, result.OK)
+	assert.JSONEq(t, "{\"hello\":\"world\"}", string(receivedBody))
+}
+
+func TestClientRequestErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad request"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key", time.Second)
+
+	err := client.get(context.Background(), server.URL+"/bad", &struct{}{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status=400")
+	assert.Contains(t, err.Error(), "bad request")
+}
+
+func TestClientRequestDecodeError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key", time.Second)
+
+	var result struct{}
+	err := client.get(context.Background(), server.URL+"/decode", &result)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode response")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -67,7 +67,9 @@ func New(cfg *config.Config) (*Server, error) {
 	)
 
 	// Register all tools
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		return nil, fmt.Errorf("failed to register tools: %w", err)
+	}
 
 	// Create StreamableHTTP server
 	streamableHTTP := server.NewStreamableHTTPServer(mcpServer)

--- a/pkg/tools/smart_album_store.go
+++ b/pkg/tools/smart_album_store.go
@@ -1,0 +1,224 @@
+package tools
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/yourusername/mcp-immich/pkg/immich"
+)
+
+const defaultSmartAlbumStorage = "data/smart_albums.json"
+
+// SmartAlbumDefinition represents a persistent smart album rule definition.
+type SmartAlbumDefinition struct {
+	ID               string                   `json:"id"`
+	Name             string                   `json:"name"`
+	Description      string                   `json:"description,omitempty"`
+	AlbumID          string                   `json:"albumId"`
+	AlbumName        string                   `json:"albumName"`
+	AlbumDescription string                   `json:"albumDescription,omitempty"`
+	Query            immich.SmartSearchParams `json:"query"`
+	MaxResults       int                      `json:"maxResults,omitempty"`
+	CreatedAt        time.Time                `json:"createdAt"`
+	UpdatedAt        time.Time                `json:"updatedAt"`
+	LastRunAt        *time.Time               `json:"lastRunAt,omitempty"`
+	LastResultCount  int                      `json:"lastResultCount,omitempty"`
+	LastAddedCount   int                      `json:"lastAddedCount,omitempty"`
+	LastRunError     string                   `json:"lastRunError,omitempty"`
+}
+
+// SmartAlbumStore manages smart album definitions persisted on disk.
+type SmartAlbumStore struct {
+	mu     sync.RWMutex
+	path   string
+	albums map[string]SmartAlbumDefinition
+	byName map[string]string
+	loaded bool
+}
+
+// NewSmartAlbumStore creates a new store instance backed by the provided file path.
+func NewSmartAlbumStore(path string) (*SmartAlbumStore, error) {
+	if path == "" {
+		path = defaultSmartAlbumStorage
+	}
+
+	store := &SmartAlbumStore{
+		path:   path,
+		albums: make(map[string]SmartAlbumDefinition),
+		byName: make(map[string]string),
+	}
+
+	if err := store.load(); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// Path returns the backing file path.
+func (s *SmartAlbumStore) Path() string {
+	return s.path
+}
+
+// load loads definitions from disk if present.
+func (s *SmartAlbumStore) load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.loaded {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			s.loaded = true
+			return nil
+		}
+		return err
+	}
+
+	if len(data) == 0 {
+		s.loaded = true
+		return nil
+	}
+
+	var defs []SmartAlbumDefinition
+	if err := json.Unmarshal(data, &defs); err != nil {
+		return err
+	}
+
+	for _, def := range defs {
+		s.albums[def.ID] = def
+		if def.Name != "" {
+			s.byName[strings.ToLower(def.Name)] = def.ID
+		}
+	}
+
+	s.loaded = true
+	return nil
+}
+
+// Save persists the definition, assigning IDs and timestamps as needed.
+func (s *SmartAlbumStore) Save(def SmartAlbumDefinition) (SmartAlbumDefinition, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if def.ID == "" {
+		def.ID = uuid.NewString()
+	}
+
+	now := time.Now().UTC()
+	if def.CreatedAt.IsZero() {
+		def.CreatedAt = now
+	}
+	def.UpdatedAt = now
+
+	s.albums[def.ID] = def
+	if def.Name != "" {
+		s.byName[strings.ToLower(def.Name)] = def.ID
+	}
+
+	if err := s.persistLocked(); err != nil {
+		return SmartAlbumDefinition{}, err
+	}
+
+	return def, nil
+}
+
+// GetByID retrieves a definition by its ID.
+func (s *SmartAlbumStore) GetByID(id string) (SmartAlbumDefinition, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	def, ok := s.albums[id]
+	return def, ok
+}
+
+// GetByName retrieves a definition by its name (case-insensitive).
+func (s *SmartAlbumStore) GetByName(name string) (SmartAlbumDefinition, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if name == "" {
+		return SmartAlbumDefinition{}, false
+	}
+
+	id, ok := s.byName[strings.ToLower(name)]
+	if !ok {
+		return SmartAlbumDefinition{}, false
+	}
+
+	def, ok := s.albums[id]
+	return def, ok
+}
+
+// List returns all stored definitions sorted by name.
+func (s *SmartAlbumStore) List() []SmartAlbumDefinition {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	defs := make([]SmartAlbumDefinition, 0, len(s.albums))
+	for _, def := range s.albums {
+		defs = append(defs, def)
+	}
+
+	sort.Slice(defs, func(i, j int) bool {
+		return strings.ToLower(defs[i].Name) < strings.ToLower(defs[j].Name)
+	})
+
+	return defs
+}
+
+// persistLocked writes the current definitions to disk. Caller must hold write lock.
+func (s *SmartAlbumStore) persistLocked() error {
+	defs := make([]SmartAlbumDefinition, 0, len(s.albums))
+	for _, def := range s.albums {
+		defs = append(defs, def)
+	}
+
+	sort.Slice(defs, func(i, j int) bool {
+		return strings.ToLower(defs[i].Name) < strings.ToLower(defs[j].Name)
+	})
+
+	data, err := json.MarshalIndent(defs, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, s.path)
+}
+
+// Delete removes a definition by ID.
+func (s *SmartAlbumStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	def, ok := s.albums[id]
+	if !ok {
+		return nil
+	}
+
+	delete(s.albums, id)
+	if def.Name != "" {
+		delete(s.byName, strings.ToLower(def.Name))
+	}
+
+	return s.persistLocked()
+}

--- a/test/move_all_broken.go
+++ b/test/move_all_broken.go
@@ -31,7 +31,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/move_broken_images.go
+++ b/test/move_broken_images.go
@@ -32,7 +32,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/move_large_movies.go
+++ b/test/move_large_movies.go
@@ -31,7 +31,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/move_remaining.go
+++ b/test/move_remaining.go
@@ -31,7 +31,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/move_small_images.go
+++ b/test/move_small_images.go
@@ -31,7 +31,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/separate_personal_videos.go
+++ b/test/separate_personal_videos.go
@@ -31,7 +31,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/smoke_test.go
+++ b/test/smoke_test.go
@@ -80,7 +80,9 @@ func setupTestServer(t *testing.T, cfg *TestConfig) *server.MCPServer {
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
 
 	// Register all tools
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		t.Fatalf("failed to register tools: %v", err)
+	}
 
 	return mcpServer
 }
@@ -203,7 +205,7 @@ func TestSpecificPhotoID(t *testing.T) {
 	t.Run("search for specific photo", func(t *testing.T) {
 		// Try to query photos and find this specific one
 		result, err := callTool(t, srv, "queryPhotos", map[string]interface{}{
-			"ids":  []string{specificPhotoID},
+			"ids":   []string{specificPhotoID},
 			"limit": 1,
 		})
 
@@ -401,7 +403,7 @@ func TestSearchByLocation(t *testing.T) {
 	srv := setupTestServer(t, cfg)
 
 	result, err := callTool(t, srv, "searchByLocation", map[string]interface{}{
-		"latitude":  40.7128,  // New York City
+		"latitude":  40.7128, // New York City
 		"longitude": -74.0060,
 		"radius":    10000, // 10km
 		"limit":     5,
@@ -813,7 +815,7 @@ func TestMoveSmallImagesToAlbum(t *testing.T) {
 		"albumName":    "Small Images Test",
 		"maxDimension": 200,
 		"dryRun":       true,
-		"maxImages":    100,  // Increased to scan more images
+		"maxImages":    100, // Increased to scan more images
 	})
 
 	require.NoError(t, err)

--- a/test/test_advanced_search.go
+++ b/test/test_advanced_search.go
@@ -53,7 +53,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/test_delete_album.go
+++ b/test/test_delete_album.go
@@ -31,7 +31,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/test_delete_small.go
+++ b/test/test_delete_small.go
@@ -31,7 +31,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 

--- a/test/test_smart_search.go
+++ b/test/test_smart_search.go
@@ -43,7 +43,9 @@ func main() {
 	immichClient := immich.NewClient(cfg.ImmichURL, cfg.ImmichAPIKey, 30*time.Second)
 	cacheStore := cache.New(5*time.Minute, 10*time.Minute)
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
-	tools.RegisterTools(mcpServer, immichClient, cacheStore)
+	if err := tools.RegisterTools(mcpServer, immichClient, cacheStore); err != nil {
+		log.Fatal("failed to register tools: ", err)
+	}
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- add a disk-backed smart album store for persisting smart search definitions
- expose new `defineSmartAlbum` and `refreshSmartAlbum` tools that create/update stored definitions and sync albums
- propagate tool registration failures so the server and test harnesses surface configuration errors early

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5be9677c4832bb1def1abe7cf888a